### PR TITLE
Add Advanced Inspect Chrome extension

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,0 +1,156 @@
+(function () {
+  if (window.__advancedInspectLoaded) return;
+  window.__advancedInspectLoaded = true;
+
+  const elementMap = new Map();
+  let graph = [];
+
+  // Load styles
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = chrome.runtime.getURL('style.css');
+  document.head.appendChild(link);
+
+  // Sidebar container
+  const sidebar = document.createElement('div');
+  sidebar.id = 'ai-sidebar';
+  document.body.appendChild(sidebar);
+
+  fetch(chrome.runtime.getURL('sidebar.html'))
+    .then(r => r.text())
+    .then(html => {
+      sidebar.innerHTML = html;
+      const script = document.createElement('script');
+      script.src = chrome.runtime.getURL('sidebar.js');
+      document.documentElement.appendChild(script);
+    });
+
+  // Highlight box
+  const highlightBox = document.createElement('div');
+  highlightBox.id = 'ai-highlight';
+  document.body.appendChild(highlightBox);
+
+  // Inject API script
+  const apiScript = document.createElement('script');
+  apiScript.src = chrome.runtime.getURL('inject.js');
+  document.documentElement.appendChild(apiScript);
+
+  function getLabel(el) {
+    if (el.id) {
+      const l = document.querySelector('label[for="' + el.id + '"]');
+      if (l) return l.innerText.trim();
+    }
+    const parent = el.closest('label');
+    if (parent) return parent.innerText.trim();
+    return '';
+  }
+
+  function generateSelector(el) {
+    if (el.id) return '#' + el.id;
+    let sel = el.tagName.toLowerCase();
+    if (el.className) {
+      const classes = el.className.trim().split(/\s+/).slice(0, 2).join('.');
+      if (classes) sel += '.' + classes;
+    }
+    return sel;
+  }
+
+  function buildGraph() {
+    graph = [];
+    elementMap.clear();
+    const selector = 'input, textarea, select, button, a[href], [role="button"], [onclick]';
+    const els = document.querySelectorAll(selector);
+    let idx = 0;
+    els.forEach(el => {
+      const id = 'ai-' + (idx++);
+      el.dataset.aiId = id;
+      const rect = el.getBoundingClientRect();
+      graph.push({
+        id,
+        type: el.tagName.toLowerCase(),
+        text: el.innerText ? el.innerText.trim() : '',
+        label: getLabel(el),
+        placeholder: el.placeholder || '',
+        value: el.value || '',
+        required: !!el.required,
+        form: el.form ? (el.form.id || el.form.name || '') : '',
+        selector: generateSelector(el),
+        rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+        visible: rect.width > 0 && rect.height > 0
+      });
+      elementMap.set(id, el);
+    });
+  }
+
+  function sendGraph() {
+    buildGraph();
+    window.postMessage({ source: 'content-script', action: 'graph', payload: graph }, '*');
+  }
+
+  function highlight(el) {
+    const rect = el.getBoundingClientRect();
+    highlightBox.style.display = 'block';
+    highlightBox.style.left = rect.left + window.scrollX + 'px';
+    highlightBox.style.top = rect.top + window.scrollY + 'px';
+    highlightBox.style.width = rect.width + 'px';
+    highlightBox.style.height = rect.height + 'px';
+  }
+
+  function hideHighlight() {
+    highlightBox.style.display = 'none';
+  }
+
+  document.addEventListener('mousemove', e => {
+    if (e.ctrlKey) {
+      const el = e.target;
+      const id = el.dataset.aiId;
+      if (id) {
+        highlight(el);
+        window.postMessage({ source: 'content-script', action: 'hover', id }, '*');
+      }
+    } else {
+      hideHighlight();
+    }
+  });
+
+  window.addEventListener('message', e => {
+    if (!e.data) return;
+    if (e.data.source === 'sidebar') {
+      const { action, id, value } = e.data;
+      if (action === 'ready') {
+        sendGraph();
+        return;
+      }
+      const el = elementMap.get(id);
+      if (!el) return;
+      switch (action) {
+        case 'highlight':
+          highlight(el);
+          break;
+        case 'setValue':
+          el.value = value;
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+          break;
+        case 'setText':
+          el.innerText = value;
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+          break;
+        case 'click':
+          el.click();
+          break;
+        case 'remove':
+          el.remove();
+          break;
+      }
+    }
+  });
+
+  const observer = new MutationObserver(() => {
+    sendGraph();
+  });
+  observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true });
+
+  sendGraph();
+})();

--- a/inject.js
+++ b/inject.js
@@ -1,0 +1,62 @@
+(function () {
+  function findByLabel(label) {
+    const labels = Array.from(document.querySelectorAll('label'));
+    for (const l of labels) {
+      if (l.innerText.trim() === label) {
+        const forId = l.getAttribute('for');
+        if (forId) return document.getElementById(forId);
+        return l.querySelector('input, textarea, select');
+      }
+    }
+    return null;
+  }
+
+  function fill({ selector, label, value }) {
+    let el = null;
+    if (selector) {
+      el = document.querySelector(selector);
+    } else if (label) {
+      el = findByLabel(label);
+    }
+    if (el) {
+      el.focus();
+      el.value = value;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  }
+
+  function click({ selector, text }) {
+    let el = null;
+    if (selector) {
+      el = document.querySelector(selector);
+    } else if (text) {
+      el = Array.from(document.querySelectorAll('button, input[type="button"], input[type="submit"], a, [role="button"]'))
+        .find(e => e.innerText.trim() === text);
+    }
+    if (el) {
+      el.click();
+    }
+  }
+
+  function remove({ selector }) {
+    const el = document.querySelector(selector);
+    if (el) el.remove();
+  }
+
+  function fillField(label, value) {
+    fill({ label, value });
+  }
+
+  function clickByText(text) {
+    click({ text });
+  }
+
+  window.__inspectAPI = {
+    fill,
+    click,
+    remove,
+    fillField,
+    clickByText
+  };
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "Advanced Inspect",
+  "version": "1.0",
+  "description": "Interactive DOM inspector and automation API.",
+  "permissions": ["scripting"],
+  "host_permissions": ["<all_urls>"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["sidebar.html", "sidebar.js", "inject.js", "style.css"],
+      "matches": ["<all_urls>"]
+    }
+  ]
+}

--- a/sidebar.html
+++ b/sidebar.html
@@ -1,0 +1,3 @@
+<h2>Advanced Inspect</h2>
+<ul id="ai-elements"></ul>
+<div id="ai-detail"></div>

--- a/sidebar.js
+++ b/sidebar.js
@@ -1,0 +1,75 @@
+(function () {
+  const listEl = document.getElementById('ai-elements');
+  const detailEl = document.getElementById('ai-detail');
+  let elements = [];
+
+  function send(message) {
+    window.postMessage(Object.assign({ source: 'sidebar' }, message), '*');
+  }
+
+  window.addEventListener('message', function (e) {
+    if (!e.data || e.data.source !== 'content-script') return;
+    const { action, payload, id } = e.data;
+    if (action === 'graph') {
+      elements = payload || [];
+      renderList();
+    } else if (action === 'hover') {
+      highlightItem(id);
+    }
+  });
+
+  function renderList() {
+    listEl.innerHTML = '';
+    elements.forEach(el => {
+      const li = document.createElement('li');
+      li.textContent = '[' + el.type + '] ' + (el.label || el.text || el.selector);
+      li.dataset.id = el.id;
+      li.addEventListener('mouseover', () => send({ action: 'highlight', id: el.id }));
+      li.addEventListener('click', () => selectElement(el.id));
+      listEl.appendChild(li);
+    });
+  }
+
+  function highlightItem(id) {
+    const li = listEl.querySelector('li[data-id="' + id + '"]');
+    if (li) {
+      listEl.querySelectorAll('li').forEach(n => n.classList.remove('hover'));
+      li.classList.add('hover');
+      li.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+  }
+
+  function selectElement(id) {
+    const el = elements.find(e => e.id === id);
+    listEl.querySelectorAll('li').forEach(n => n.classList.toggle('active', n.dataset.id === id));
+    renderDetail(el);
+  }
+
+  function renderDetail(el) {
+    detailEl.innerHTML = '';
+    if (!el) return;
+    const title = document.createElement('div');
+    title.textContent = el.selector;
+    detailEl.appendChild(title);
+
+    const inp = document.createElement('input');
+    const editableValue = (el.type === 'input' || el.type === 'textarea' || el.type === 'select');
+    inp.value = editableValue ? (el.value || '') : (el.text || '');
+    inp.addEventListener('change', () => {
+      send({ action: editableValue ? 'setValue' : 'setText', id: el.id, value: inp.value });
+    });
+    detailEl.appendChild(inp);
+
+    const btnClick = document.createElement('button');
+    btnClick.textContent = 'Click';
+    btnClick.addEventListener('click', () => send({ action: 'click', id: el.id }));
+    detailEl.appendChild(btnClick);
+
+    const btnRemove = document.createElement('button');
+    btnRemove.textContent = 'Remove';
+    btnRemove.addEventListener('click', () => send({ action: 'remove', id: el.id }));
+    detailEl.appendChild(btnRemove);
+  }
+
+  send({ action: 'ready' });
+})();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,76 @@
+#ai-sidebar {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 300px;
+  height: 100%;
+  background: #1e1e1e;
+  color: #eee;
+  font-family: Arial, sans-serif;
+  font-size: 14px;
+  z-index: 2147483647;
+  border-left: 1px solid #333;
+  overflow-y: auto;
+}
+
+#ai-sidebar h2 {
+  margin: 0;
+  padding: 10px;
+  font-size: 16px;
+  background: #222;
+  border-bottom: 1px solid #333;
+}
+
+#ai-elements {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#ai-elements li {
+  padding: 4px 8px;
+  border-bottom: 1px solid #333;
+  cursor: pointer;
+}
+
+#ai-elements li:hover,
+#ai-elements li.hover,
+#ai-elements li.active {
+  background: #333;
+}
+
+#ai-detail {
+  padding: 8px;
+  border-top: 1px solid #333;
+}
+
+#ai-detail input {
+  width: 100%;
+  margin-bottom: 6px;
+  background: #222;
+  color: #eee;
+  border: 1px solid #555;
+  padding: 4px;
+}
+
+#ai-detail button {
+  margin-right: 4px;
+  background: #444;
+  color: #eee;
+  border: 1px solid #555;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+#ai-detail button:hover {
+  background: #555;
+}
+
+#ai-highlight {
+  position: absolute;
+  pointer-events: none;
+  border: 2px solid #ff9800;
+  background: rgba(255, 152, 0, 0.2);
+  z-index: 2147483646;
+  display: none;
+}


### PR DESCRIPTION
## Summary
- add Manifest V3 Chrome extension scaffolding for Advanced Inspect
- implement DOM scanning content script and sidebar UI with live editing
- expose page-level __inspectAPI for scripted fill/click/remove actions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ef63608708325aa52a930be2a8a15