### PR TITLE
Add Advanced Inspect Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# extenstion
+# Advanced Inspect Chrome Extension
+
+A Chrome extension providing an interactive sidebar for inspecting and manipulating web page elements. It scans the DOM, builds a semantic graph of interactive elements, and exposes a simple API for automation scripts.
+
+## Installation
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this folder.
+
+Once installed, visit any page to see the sidebar and use the `window.__inspectAPI` methods.

--- a/content.js
+++ b/content.js
@@ -1,0 +1,88 @@
+// content.js - scans DOM, builds element graph, injects sidebar UI
+
+(async function() {
+  const SIDEBAR_ID = 'ai-sidebar-container';
+  const GRAPH_EVENT = 'ai-graph';
+
+  // Inject helper script into page context for API and DOM functions
+  const injectScript = document.createElement('script');
+  injectScript.src = chrome.runtime.getURL('inject.js');
+  (document.head || document.documentElement).appendChild(injectScript);
+
+  // Create floating sidebar
+  const container = document.createElement('div');
+  container.id = SIDEBAR_ID;
+  container.style.position = 'fixed';
+  container.style.top = '0';
+  container.style.right = '0';
+  container.style.width = '300px';
+  container.style.height = '100vh';
+  container.style.zIndex = '2147483647';
+  container.style.background = '#1e1e1e';
+  container.style.boxShadow = '0 0 10px rgba(0,0,0,0.5)';
+  container.style.color = '#fff';
+  container.style.fontFamily = 'monospace';
+  container.style.overflow = 'auto';
+
+  const sidebarHTML = await fetch(chrome.runtime.getURL('sidebar.html')).then(r => r.text());
+  container.innerHTML = sidebarHTML;
+  document.body.appendChild(container);
+
+  // Load sidebar script
+  const sidebarScript = document.createElement('script');
+  sidebarScript.src = chrome.runtime.getURL('sidebar.js');
+  container.appendChild(sidebarScript);
+
+  // Build initial graph and send to sidebar
+  function scan() {
+    const elements = Array.from(document.querySelectorAll('input, button, select, textarea, a[href], [role="button"], form'));
+    const graph = elements.map((el, idx) => {
+      const rect = el.getBoundingClientRect();
+      return {
+        id: el.id || `ai-${idx}`,
+        type: el.tagName.toLowerCase(),
+        text: el.innerText || el.value || '',
+        label: el.getAttribute('aria-label') || (el.labels && el.labels[0] ? el.labels[0].innerText : ''),
+        placeholder: el.placeholder || '',
+        value: el.value || '',
+        required: el.required || false,
+        form: el.form ? (el.form.id || el.form.name || '') : '',
+        selector: getSelector(el),
+        rect: {x: rect.x, y: rect.y, width: rect.width, height: rect.height},
+        visible: !!(rect.width || rect.height)
+      };
+    });
+    postToSidebar({type: GRAPH_EVENT, graph});
+  }
+
+  function getSelector(el) {
+    if (el.id) return `#${el.id}`;
+    const parts = [];
+    if (el.className) {
+      const cls = el.className.toString().trim().replace(/\s+/g, '.');
+      parts.push(`${el.tagName.toLowerCase()}.${cls}`);
+    } else {
+      parts.push(el.tagName.toLowerCase());
+    }
+    return parts.join('');
+  }
+
+  function postToSidebar(data) {
+    window.postMessage({__inspect: true, target: 'sidebar', data});
+  }
+
+  // Listen for messages from sidebar
+  window.addEventListener('message', (event) => {
+    const msg = event.data;
+    if (!msg || !msg.__inspect || msg.target !== 'content') return;
+    const {action, payload} = msg;
+    window.postMessage({__inspect: true, action, payload}, '*');
+  });
+
+  // Observe DOM changes
+  const observer = new MutationObserver(() => scan());
+  observer.observe(document.documentElement, {subtree: true, childList: true, attributes: true});
+
+  // Initial scan
+  scan();
+})();

--- a/inject.js
+++ b/inject.js
@@ -1,0 +1,84 @@
+// inject.js - runs in page context, exposes __inspectAPI and handles DOM ops
+(function() {
+  let highlightBox;
+
+  function highlightElement(selector) {
+    if (!selector) {
+      if (highlightBox) highlightBox.remove();
+      return;
+    }
+    const el = document.querySelector(selector);
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    if (!highlightBox) {
+      highlightBox = document.createElement('div');
+      highlightBox.style.position = 'absolute';
+      highlightBox.style.border = '2px solid #00ffff';
+      highlightBox.style.zIndex = '2147483647';
+      document.body.appendChild(highlightBox);
+    }
+    highlightBox.style.left = rect.x + 'px';
+    highlightBox.style.top = rect.y + 'px';
+    highlightBox.style.width = rect.width + 'px';
+    highlightBox.style.height = rect.height + 'px';
+  }
+
+  function setValue(selector, value) {
+    const el = document.querySelector(selector);
+    if (!el) return;
+    if ('value' in el) {
+      el.value = value;
+      el.dispatchEvent(new Event('input', {bubbles: true}));
+      el.dispatchEvent(new Event('change', {bubbles: true}));
+    } else {
+      el.textContent = value;
+    }
+  }
+
+  function click(selector) {
+    const el = document.querySelector(selector);
+    if (el) el.click();
+  }
+
+  function fillField({label, value}) {
+    const el = Array.from(document.querySelectorAll('input, textarea, select')).find(e => {
+      const lbl = e.getAttribute('aria-label') || (e.labels && e.labels[0] ? e.labels[0].innerText : '');
+      return lbl.trim().toLowerCase() === label.trim().toLowerCase();
+    });
+    if (el) setValue(getSelector(el), value);
+  }
+
+  function clickByText(text) {
+    const el = Array.from(document.querySelectorAll('button, [role="button"], a, input[type="button"], input[type="submit"]')).find(e => e.innerText.trim() === text.trim());
+    if (el) el.click();
+  }
+
+  function removeBySelector(selector) {
+    const el = document.querySelector(selector);
+    if (el) el.remove();
+  }
+
+  function getSelector(el) {
+    if (el.id) return `#${el.id}`;
+    const parts = [el.tagName.toLowerCase()];
+    if (el.className) parts.push('.' + el.className.toString().trim().replace(/\s+/g, '.'));
+    return parts.join('');
+  }
+
+  window.addEventListener('message', (event) => {
+    const data = event.data;
+    if (!data || !data.__inspect) return;
+    const {action, payload} = data;
+    if (action === 'highlight') highlightElement(payload.selector);
+    if (action === 'set') setValue(payload.selector, payload.value);
+    if (action === 'click') click(payload.selector);
+    if (action === 'remove') removeBySelector(payload.selector);
+    if (action === 'fill') fillField(payload);
+  });
+
+  window.__inspectAPI = {
+    clickByText,
+    fillField,
+    remove: removeBySelector
+  };
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "Advanced Inspect",
+  "version": "1.0",
+  "description": "Advanced Inspect tool for interactive DOM analysis and manipulation.",
+  "permissions": ["scripting"],
+  "host_permissions": ["<all_urls>"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "css": ["style.css"],
+      "run_at": "document_idle"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["sidebar.html", "sidebar.js", "style.css", "inject.js"],
+      "matches": ["<all_urls>"]
+    }
+  ]
+}

--- a/sidebar.html
+++ b/sidebar.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="style.css" />
+</head>
+<body class="ai-sidebar">
+  <h2>Advanced Inspect</h2>
+  <div id="elements"></div>
+</body>
+</html>

--- a/sidebar.js
+++ b/sidebar.js
@@ -1,0 +1,43 @@
+// sidebar.js - renders element graph and interactions within sidebar
+(function() {
+  const elementsDiv = document.getElementById('elements');
+  window.addEventListener('message', (event) => {
+    const msg = event.data;
+    if (!msg || !msg.__inspect || msg.target !== 'sidebar') return;
+    if (msg.data && msg.data.type === 'ai-graph') {
+      render(msg.data.graph);
+    }
+  });
+
+  function render(graph) {
+    elementsDiv.innerHTML = '';
+    graph.forEach(item => {
+      const row = document.createElement('div');
+      row.className = 'ai-row';
+      row.textContent = `${item.type} - ${item.label || item.text || item.selector}`;
+      row.addEventListener('mouseenter', () => highlight(item.selector));
+      row.addEventListener('mouseleave', () => highlight(null));
+      row.addEventListener('click', () => edit(item));
+
+      const clickBtn = document.createElement('button');
+      clickBtn.textContent = 'click';
+      clickBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        parent.postMessage({__inspect: true, target: 'content', action: 'click', payload: {selector: item.selector}}, '*');
+      });
+      row.appendChild(clickBtn);
+      elementsDiv.appendChild(row);
+    });
+  }
+
+  function highlight(selector) {
+    parent.postMessage({__inspect: true, target: 'content', action: 'highlight', payload: {selector}}, '*');
+  }
+
+  function edit(item) {
+    const newVal = prompt('New value/text:', item.value || item.text || '');
+    if (newVal !== null) {
+      parent.postMessage({__inspect: true, target: 'content', action: 'set', payload: {selector: item.selector, value: newVal}}, '*');
+    }
+  }
+})();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,32 @@
+/* style.css - shared styles for Advanced Inspect */
+#ai-sidebar-container {
+  font-size: 12px;
+}
+.ai-sidebar {
+  margin: 0;
+  padding: 8px;
+  background: #1e1e1e;
+  color: #eee;
+  font-family: monospace;
+}
+.ai-row {
+  padding: 4px;
+  border-bottom: 1px solid #333;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.ai-row:hover {
+  background: #333;
+}
+.ai-row button {
+  background: #444;
+  color: #fff;
+  border: none;
+  padding: 2px 4px;
+  cursor: pointer;
+}
+.ai-row button:hover {
+  background: #666;
+}


### PR DESCRIPTION
## Summary
- add Manifest V3 setup for Advanced Inspect extension
- build content script that scans DOM elements and injects sidebar
- provide sidebar and inject scripts for highlighting, editing, and automation API

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ef63608708325aa52a930be2a8a15